### PR TITLE
A simple profiling mechanism, based on per-position context creation fre...

### DIFF
--- a/contexts.lisp
+++ b/contexts.lisp
@@ -47,6 +47,7 @@
 
 (defmethod make-context-at-position :around ((context context) position)
   (let ((cache (cache-of context)))
+    (note-position position)
     (etypecase cache
       (null (call-next-method))
       (vector (or (aref cache position)
@@ -178,6 +179,12 @@
                      :common (make-instance 'context-common
                                             :length (length list)
                                             :cache (make-cache cache-type (length list))))))
+
+(defmethod initialize-instance :around ((context context) &rest initargs &key &allow-other-keys)
+  (declare (ignore initargs))
+  (let ((rest (call-next-method)))
+    (note-position (slot-value rest 'position))
+    rest))
 
 (defmethod make-context ((vector vector) &optional (cache-type *default-context-cache*))
   (if (zerop (length vector))


### PR DESCRIPTION
This suffers from always paying the profiling overhead, but a single hash-table insert
should be relatively tame, in context..

This is just the plumbing layer, upon which I have a "pain point visualisation" pretty-printer,
which overlays points of contention over the parsed text, like this:

;   \* core slimefuns
;     - [ ] ping
;     - [X] create-repl
;     - [ ] create-listener
;     - [X] connection-info
;     - [ ] io-speed-test
;     - [ ] toggle-debug-on-swank-error
;     - [X] interactive-eval
;;; ^  193 hits, posn 156:7:0
;     - [X] eval-and-grab-output
;;; ^  385 hits, posn 181:8:0
;;;   ^  257 hits, posn 183:8:2
;;;  ^  257 hits, posn 182:8:1

NOTE: This is an updated version, which fixes a gotcha where cached context references were not counted.
